### PR TITLE
Create from_dict method for Interface and UNI

### DIFF
--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -405,6 +405,17 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             iface_dict['stats'] = self.stats.as_dict()
         return iface_dict
 
+    @classmethod
+    def from_dict(cls, interface_dict):
+        """Return a Interface instance from python dictionary."""
+        return cls(interface_dict.get('name'),
+                   interface_dict.get('port_number'),
+                   interface_dict.get('switch'),
+                   interface_dict.get('address'),
+                   interface_dict.get('state'),
+                   interface_dict.get('features'),
+                   interface_dict.get('speed'))
+
     def as_json(self):
         """Return a json with Interfaces attributes.
 
@@ -449,6 +460,12 @@ class UNI:
         """Return a dict representating a UNI object."""
         return {'interface_id': self.interface.id,
                 'tag': self.user_tag.as_dict()}
+
+    @classmethod
+    def from_dict(cls, uni):
+        """Return a Uni instance from python dictionary."""
+        return cls(uni.get('interface'),
+                   uni.get('user_tag'))
 
     def as_json(self):
         """Return a json representating a UNI object."""


### PR DESCRIPTION
Some classes, like Interface and UNI, do not have a from_dict method. This commit solves this problem.